### PR TITLE
feat(transfer): Add interfaces and structures for resumable file transfers

### DIFF
--- a/src/api/rest_api_handler.hpp
+++ b/src/api/rest_api_handler.hpp
@@ -30,12 +30,19 @@ public:
         const http::request<http::string_body>& req);
     boost::asio::awaitable<http::response<http::string_body>> handle_reject_request(
         const http::request<http::string_body>& req);
-    boost::asio::awaitable<http::response<http::string_body>> handle_send_file(
-        const http::request<http::string_body>& req);
     boost::asio::awaitable<http::response<http::string_body>> handle_finish_transfer(
         const http::request<http::string_body>& req);
     boost::asio::awaitable<http::response<http::string_body>> handle_cancel_transfer(
         const http::request<http::string_body>& req);
+
+    // 查询传输状态 (GET /status/{transfer_id})
+    boost::asio::awaitable<http::response<http::string_body>> handle_get_transfer_status(
+        const http::request<http::string_body>& req, uint64_t transfer_id);
+
+    // 下载文件块 (GET /chunk/{transfer_id}/{chunk_index})
+    // 注意: 响应体类型可能需要调整为二进制类型
+    boost::asio::awaitable<http::response<http::vector_body<char>>> handle_download_chunk(
+        const http::request<http::string_body>& req, uint64_t transfer_id, uint64_t chunk_index);
 
     // 为Electron预留的事件流接口
     boost::asio::awaitable<http::response<http::string_body>> handle_events_stream(

--- a/src/transfer/transfer_manager.hpp
+++ b/src/transfer/transfer_manager.hpp
@@ -3,6 +3,7 @@
 #include "../discovery/discovery_manager.hpp"
 #include "../util/config.hpp"
 #include "../util/logger.hpp"
+#include "transfer_metadata.hpp"
 #include <atomic>
 #include <boost/asio.hpp>
 #include <chrono>
@@ -52,6 +53,7 @@ public:
     // 状态查询
     std::optional<TransferState> get_transfer_state(uint64_t transfer_id) const;
     std::vector<TransferState> get_active_transfers() const;
+    std::optional<lansend::TransferMetadata> get_transfer_metadata(uint64_t transfer_id) const;
 
 private:
     boost::asio::io_context& io_context_;

--- a/src/transfer/transfer_metadata.cpp
+++ b/src/transfer/transfer_metadata.cpp
@@ -1,0 +1,3 @@
+#include "transfer_metadata.hpp"
+
+//后续实现

--- a/src/transfer/transfer_metadata.hpp
+++ b/src/transfer/transfer_metadata.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+#include <toml++/toml.hpp>
+
+namespace lansend {
+
+struct ChunkInfo {
+    uint64_t index;
+    std::string hash;
+    // Add status etc. as needed
+    bool completed = false;
+};
+
+class TransferMetadata {
+   public:
+    // Constructor (consider parameters needed for creation/loading)
+    TransferMetadata(uint64_t transfer_id, const std::string& filename,
+                     uint64_t file_size, const std::string& file_hash,
+                     uint64_t chunk_size);
+
+    // Factory method or similar to create new metadata and potentially save it initially
+    static std::optional<TransferMetadata> create(
+        const std::filesystem::path& metadata_dir, uint64_t transfer_id,
+        const std::string& filename, uint64_t file_size,
+        const std::string& file_hash, uint64_t chunk_size);
+
+    // Load metadata from persistent storage (e.g., TOML file)
+    static std::optional<TransferMetadata> load(
+        const std::filesystem::path& metadata_dir, uint64_t transfer_id);
+
+    // Save metadata to persistent storage
+    bool save(const std::filesystem::path& metadata_dir) const;
+
+    // Update the status of a specific chunk
+    bool update_chunk_status(uint64_t chunk_index, bool completed);
+
+    // Find the index of the next chunk that needs to be transferred
+    std::optional<uint64_t> get_next_incomplete_chunk_index() const;
+
+    // --- Getters ---
+    uint64_t get_transfer_id() const;
+    const std::string& get_filename() const;
+    uint64_t get_file_size() const;
+    const std::string& get_file_hash() const;
+    uint64_t get_chunk_size() const;
+    uint64_t get_completed_size() const; // Needs calculation based on chunks
+    const std::vector<ChunkInfo>& get_chunks() const;
+    uint64_t get_total_chunks() const; // Needs calculation
+
+   private:
+    // Calculate total chunks based on file size and chunk size
+    void calculate_initial_chunks();
+    // Helper to get the path to the metadata file
+    static std::filesystem::path get_metadata_filepath(
+        const std::filesystem::path& metadata_dir, uint64_t transfer_id);
+
+    uint64_t transfer_id_;
+    std::string filename_;
+    uint64_t file_size_;
+    std::string file_hash_;
+    uint64_t chunk_size_;
+    uint64_t completed_size_ = 0; // Track completed size
+    std::vector<ChunkInfo> chunks_;
+    // Add other necessary members, e.g., transfer status (pending, active, completed, failed)
+};
+
+}  // namespace lansend

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "boost-filesystem",
     "nlohmann-json",
     "openssl",
-    "spdlog"
+    "spdlog",
+    "tomlplusplus"
   ]
 }


### PR DESCRIPTION
*   **Added:** Introduced `toml++` as a dependency via vcpkg to handle TOML serialization/deserialization for persisting transfer metadata.
*   **Added:** Created `src/transfer/transfer_metadata.hpp`, defining the `TransferMetadata` class with its core members and method declarations to manage the state and chunk information for individual transfers, designed for TOML persistence.
*   **Modified:** Updated `src/transfer/transfer_manager.hpp`:
    *   Included `transfer_metadata.hpp`.
    *   Added the `get_transfer_metadata()` method declaration to retrieve detailed transfer metadata.
    *   Fixed the namespace issue for `lansend::TransferMetadata` in the return type of `get_transfer_metadata`.
*   **Modified:** Updated `src/api/rest_api_handler.hpp`:
    *   Added the `handle_get_transfer_status()` method declaration (corresponding to the `GET /status/{transfer_id}` API).
    *   Added the `handle_download_chunk()` method declaration (corresponding to the `GET /chunk/{transfer_id}/{chunk_index}` API).