### PR TITLE
fix: fix compilation errors on Windows platform

### DIFF
--- a/src/api/http_server.cpp
+++ b/src/api/http_server.cpp
@@ -263,4 +263,3 @@ boost::asio::awaitable<AnyResponse> HttpServer::handle_request(HttpRequest&& req
 
 } // namespace api
 } // namespace lansend
-

--- a/src/constants/path.hpp
+++ b/src/constants/path.hpp
@@ -2,6 +2,12 @@
 
 #include <filesystem>
 
+#if defined(_WIN32) || defined(_WIN64)
+#include <combaseapi.h>
+#include <knownfolders.h>
+#include <shlobj_core.h>
+#endif
+
 namespace lansend {
 namespace path {
 
@@ -26,7 +32,7 @@ inline const std::filesystem::path kConfigDir =
     std::filesystem::path(std::getenv("HOME")) / ".config" / "CodeSoul" / "LanSend";
 #endif
 
-inline const std::filesystem::path kSystemDownloadDir = [] {
+inline const std::filesystem::path kSystemDownloadDir = []() -> std::filesystem::path {
 #if defined(_WIN32) || defined(_WIN64)
     PWSTR path = nullptr;
     if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Downloads, 0, nullptr, &path))) {


### PR DESCRIPTION
## 改动
1. 更新[path.hpp]：
   - 替换`<shlobj.h>`为`<shlobj_core.h>`
   - 添加`<combaseapi.h>`以解决COM API函数未声明问题
   - 为lambda表达式添加明确的返回类型声明`[]() -> std::filesystem::path`
   - 调整了include顺序以符合项目风格

2. 更新[network_manager.cpp]：
   - 调整NetworkManager的构造函数